### PR TITLE
update ternary example

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We may then change the value of our counter through the Store `.set()` method. L
  ```
   const addOne = (x) => x + 1
 
-  const lessOne = (x) => (x > 0) x - 1 : 0
+  const lessOne = (x) => (x > 0) ? x - 1 : 0
 
   app.load('myStore').provide(addOne, lessOne)
  ```


### PR DESCRIPTION
In the `README` an example using a ternary was missing the `?`